### PR TITLE
Update BUILD.md

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -12,7 +12,6 @@ export default {
   SENTRY_DNS:
     'Your sentry DNS URL',
   STRIPE_API_KEY: 'Your Stripe publish key',
-  STRIPE_SECRET_KEY: 'Your Stripe secret key',
   STRIPE_CLIENT_ID: 'Your Stripe client key',
 }
 ```


### PR DESCRIPTION
Stripe Secret key is not used in the code and not needed since it is embedded in the Sharetribe BE.
Adding it to the app's variables is an unnecessary security risk